### PR TITLE
fix: Update the description of callbackFn's accumulator in `Array.reduceRight()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -27,7 +27,7 @@ reduceRight(callbackFn, initialValue)
 - `callbackFn`
   - : A function to execute for each element in the array. Its return value becomes the value of the `accumulator` parameter on the next invocation of `callbackFn`. For the last invocation, the return value becomes the return value of `reduceRight()`. The function is called with the following arguments:
     - `accumulator`
-      - : The value previously returned in the last invocation of the callback, or `initialValue`, if supplied. (See below.)
+      - : The value resulting from the previous call to `callbackFn`. On first call, `initialValue` if specified, otherwise the value of the last element in the array. (See below.)
     - `currentValue`
       - : The current element being processed in the array.
     - `index`


### PR DESCRIPTION
### Description

Such as the title.

### Motivation

In order to avoid ambiguity and be consistent with `Array.reduce()`。

### Additional details

None.

### Related issues and pull requests

https://github.com/mdn/translated-content/pull/13024